### PR TITLE
Create bootstrap/workflow for integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# FACCookBookServer
+
+## Setup
+
+To setup the server ensure you have Node version `0.10.40` installed. Then run
+`npm install` which will install all the required dependencies.
+
+## Run the App
+
+Run the app by simply typing `./bin/server.js` which will bind by default to
+port 5000. You can change the port by setting the `PORT` environment variable
+(ex: `PORT=3000 ./bin/server.js`).
+
+## Running tests
+
+Ensure you have `gulp` installed globally (`npm install -g gulp`) then run
+`gulp`.
+
+You can run the tests automatically after every change by using the `gulp
+watch` command.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,17 @@
+var gulp = require('gulp');
+var gmocha = require('gulp-mocha');
+var gutil = require('gulp-util');
+
+gulp.task('mocha', function () {
+  return gulp.src(['tests/**/*.js', '!tests/lib/**/*.js'], { read: false })
+    .pipe(gmocha({
+      reporter: 'spec'
+    }));
+});
+
+gulp.task('watch', function () {
+  return gulp.watch(
+    ['lib/**/*.js', 'tests/**/*.js', '!tests/lib/**/*.js'], ['mocha']);
+});
+
+gulp.task('default', ['mocha']);

--- a/lib/api.js
+++ b/lib/api.js
@@ -41,7 +41,33 @@ CookbookServer.prototype.configure = function() {
   });
 };
 
-CookbookServer.prototype.start = function() {
-  this._server.listen(this._config.port);
-  console.log('Server listening on port', this._config.port);
+CookbookServer.prototype.start = function(cb) {
+
+  cb = cb || function () {};
+
+  var port = process.env.PORT || this._config.port;
+  this._server.listen(port, function(err) {
+    if (err) {
+      console.log('Could not start server: ', err)
+      return cb(err);
+    }
+
+    console.log('Server listening on port', port);
+    cb();
+  });
+};
+
+CookbookServer.prototype.stop = function (cb) {
+
+  cb = cb || function () {};
+
+  this._server.close(function(err) {
+    if (err) {
+      console.log('Could not stop server: ', err);
+      return cb(err);
+    }
+
+    console.log('Server has stopped successfully');
+    cb();
+  });
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node bin/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/gulp test"
   },
   "repository": {
     "type": "git",
@@ -26,5 +26,13 @@
     "pg-hstore": "2.3.2",
     "q": "1.4.1",
     "sequelize": "3.4.1"
+  },
+  "devDependencies": {
+    "gulp": "3.9.0",
+    "gulp-mocha": "2.1.3",
+    "gulp-util": "3.0.6",
+    "mocha": "2.2.5",
+    "request": "2.60.0",
+    "sinon": "1.15.4"
   }
 }

--- a/tests/integration/api.js
+++ b/tests/integration/api.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var assert = require('assert');
+
+var Bootstrap = require('../lib/bootstrap');
+var Client = require('../lib/client');
+
+describe('Server Integration', function() {
+
+  var strap = new Bootstrap();
+  var client = new Client(strap.config());
+
+  before(function(done) {
+    strap.start(done);
+  })
+  after(function(done) {
+    strap.stop(done);
+  });
+  
+  it('returns 200 ok for /status route', function (done) {
+    client.request({ path: '/status' }, function (err, res, body) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(
+        res.headers['content-type'], 'application/json; charset=utf-8');
+
+      assert.ok(body);
+      assert.strictEqual(body.status, 'ok');
+
+      done();
+    });
+  });
+
+  it('returns 404 not found for unknown route', function (done) {
+    client.request({ path: '/hello/are/you/here'}, function (err, res, body) {
+      if (err) {
+        return done(err);
+      }
+
+      assert.strictEqual(res.statusCode, 404);
+
+      assert.ok(body);
+      assert.strictEqual(body.status, 'not found');
+
+      done();
+    });
+  });
+});

--- a/tests/lib/bootstrap.js
+++ b/tests/lib/bootstrap.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var _ = require('lodash');
+
+var CookbookServer = require('../../lib/api');
+
+module.exports = Bootstrap;
+
+var DEFAULT_CONFIG = {
+  port: 7000
+};
+
+function Bootstrap (cfg) {
+  cfg = _.defaults(cfg || {}, DEFAULT_CONFIG);
+
+  this._cbServer = new CookbookServer(cfg);
+  this._cbServer.configure();
+}
+
+Bootstrap.prototype.config = function () {
+  return this._cbServer._config;
+}
+
+Bootstrap.prototype.start = function (cb) {
+  this._cbServer.start(cb);
+};
+
+Bootstrap.prototype.stop = function (cb) {
+  this._cbServer.stop(cb);
+};

--- a/tests/lib/client.js
+++ b/tests/lib/client.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var url = require('url');
+
+var _ = require('lodash');
+var request = require('request');
+
+module.exports = Client;
+
+function Client(opts) {
+  if (!opts || !_.isObject(opts)) {
+    throw new Error('You must provide an opts object');
+  }
+
+  if (!opts.port || !_.isNumber(opts.port)) {
+    throw new Error('You must provide a port');
+  }
+
+  if (opts.headers && !_.isObject(opts.headers)) {
+    throw new Error('Headers must be an object');
+  }
+
+  this.secure = opts.secure || false;
+  this.host = opts.host || 'localhost';
+  this.port = opts.port;
+  this.headers = opts.headers || {}; // Default headers
+}
+
+Client.prototype.request = function(opts, cb) {
+  if (!opts || !_.isObject(opts)) {
+    throw new Error('You must provide an opts object');
+  }
+  if (!cb || !_.isFunction(cb)) {
+    throw new Error('You must provide a callback');
+  }
+  if (opts.json && opts.body) {
+    throw new Error('You cannot specify a json and body at the same time');
+  }
+
+  var protocol = (this.secure) ? 'https' : 'http';
+
+  var nonStandardPort = (!_.include([80, 443], this.port));
+  var host = this.host;
+  if (nonStandardPort) {
+    host = this.host + ':' + this.port;
+  }
+
+  var apiUrl = url.format({
+    protocol: protocol,
+    host: host,
+    pathname: opts.path,
+    query: opts.query
+  });
+
+  var reqOpts = {
+    url: apiUrl,
+    method: opts.method || 'GET',
+    json: opts.json,
+    headers: opts.headers,
+    body: opts.body,
+    strictSSL: false,
+    timeout: 2500 // This shouldn't need to be this high
+  };
+
+  var self = this;
+  request(reqOpts, function (err, res, data) {
+    if (err) {
+      return cb(err);
+    }
+
+    // Assume if there is a body, it's JSON
+    if (data && _.isString(data)) {
+      try {
+        data = JSON.parse(data);
+      } catch (err) {
+        log.error('Error parsing response', data);
+        return cb(err);
+      }
+    }
+
+    cb.apply(null, [err, res, data]);
+  });
+};


### PR DESCRIPTION
You can now write and run integration tests for the server using the
bootstrap that is provided in `test/lib/bootstrap.js`.

Take a look at `tests/integration/api.js` for examples of how to write a
test.

You can run the tests with gulp (make sure to `npm install -g gulp`)
with `gulp` or `gulp mocha`.

I've included a README with instructions.
